### PR TITLE
CSS Images fix

### DIFF
--- a/inline-styles.js
+++ b/inline-styles.js
@@ -23,7 +23,7 @@ module.exports = function(html, base, minify) {
       el = dom(el);
       var href = el.attr('href');
       if (el.attr('rel') === 'stylesheet' && isLocal(href)) {
-        var dir = path.dirname(href);
+        var dir = base + path.dirname(href);
         var file = path.join(base, href);
         var style = fs.readFileSync(file);
         var inlined = inliner.css(style.toString(), { cssBasePath: dir });


### PR DESCRIPTION
The CSS base path was not including the cwd base path and failing to find referenced images.
