### PR TITLE
Get resources over HTTP

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "object-assign": "^1.0.0",
     "oust": "^0.2.0",
     "penthouse": "^0.2.5",
+    "request": "^2.51.0",
     "slash": "^1.0.0",
     "tmp": "0.0.24"
   },


### PR DESCRIPTION
Kind of addresses https://github.com/addyosmani/critical/issues/19

This is a super rough outline of an approach that let's you specify `remoteUrl` and `externalDomains` and get HTML and CSS over HTTP.

example usage:

```
critical.generateInline({
    base: 'dist/',
    remoteUrl: 'http://somesite.com',
    externalDomains: ['http://cdn.somesite.com']
});
```

It might be better to dump the HTML to disk, generate the new version and text diff the two, so that you can better see where to update your templates.

This still needs:
* tests coverage
* better error management
* comments