### PR TITLE
Add support for multi-dimension critical css.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ critical.generate({
 });
 ```
 
+### Generate critical-path CSS with multiple resolutions
+
+When your site is adaptive and you want to deliver critical CSS for multiple screen resolutions this is a useful option.
+*note:* (your final output will be minified as to eliminate duplicate rule inclusion)
+
+```js
+critical.generate({
+    base: 'test/',
+    src: 'index.html',
+    dest: 'styles/main.css',
+    dimensions: [{
+        height: 200,
+        width: 500
+    }, {
+        height: 900,
+        width: 1200
+    }]
+});
+```
+
 ### Inline `<style>` / critical CSS from generation
 
 Basic usage:
@@ -156,6 +176,7 @@ critical.inline({
 | dest             | `string`      | Location of where to save the output of an operation |
 | width            | `integer`     | (Generation only) Width of the target viewport |
 | height           | `integer`     | (Generation only) Height of the target viewport |
+| dimensions       | `array`       | (Generation only) an array of objects containing height and width.
 | minify           | `boolean`     | Enable minification of CSS output |
 | extract          | `boolean`     | Remove the inlined styles from any stylesheets referenced in the HTML. It generates new references based on extracted content so it's safe to use for multiple HTML files referencing the same stylesheet|
 | styleTarget      | `string`      | (`generateInline` only) Destination for critical-path styles |

--- a/test/fixture/styles/critical-adaptive.css
+++ b/test/fixture/styles/critical-adaptive.css
@@ -1,0 +1,24 @@
+@media screen and (min-width: 900px) {
+    div  {
+        height: 400px;
+        background: brown;
+    }
+}
+
+#revenge {
+    background: papayawhip;
+}
+
+#of {
+    background: teal;
+}
+
+#guybrush {
+    color: pink;
+}
+
+#threepwood {
+    background: 'orange';
+    content: 'monkey island';
+}
+

--- a/test/test.js
+++ b/test/test.js
@@ -54,6 +54,25 @@ describe('Module', function () {
         });
     });
 
+    it('generates multi-dimension critical-path CSS successfully', function (done) {
+        var expected = fs.readFileSync('fixture/test-adaptive-final.css', 'utf8');
+        critical.generate({
+            base: 'fixture/',
+            src: 'test-adaptive.html',
+            dimensions: [{
+                width: 100,
+                height: 70
+            }, {
+                width: 1000,
+                height: 70
+            }]
+        }, function (err, output) {
+            assert.strictEqual(stripWhitespace(output), stripWhitespace(expected));
+            done();
+        });
+    });
+
+
     it('generates minified critical-path CSS successfully', function (done) {
         var expected = fs.readFileSync('fixture/styles/critical-min.css', 'utf8');
 


### PR DESCRIPTION
#### What

This is useful when you want to deliver multiple dimensions
of critical css. Take for instance when your site has different elements
visible at different resolutions. Prior to this work you were limited to
multiple critical passes and inclusions or simply picking one
resolution.

#### Why is this better?

I am glad you asked yourself that. Since we use
clean-css we can intelligently merge the multiple resolution snapshots
making for smaller and better multi snapshot rule generation.

#### Why did I do this?

While working on a website I noticed that we were getting a flash of
styles after the normal stylesheet was loaded. This was not so bad on a
computer screen (since that was the dimension that we targeted) however
when on a phone it was quite a jarring experience.

-------

Thanks for this great tool and great work keeping this library kick butt!
:kimono: :gem: :haircut: 