### PR TITLE
Allows pathPrefix to be set through options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ critical.inline({
 | htmlTarget       | `string`      | (`generateInline` only) Destination for (critical-path CSS) style-inlined HTML |
 | inlineImages     | `boolean`     | Inline images (default: false)
 | maxImageFileSize | `integer`     | Sets a max file size (in bytes) for base64 inlined images
+| pathPrefix       | `string`      | (defaults to `/`) Path to prepend CSS assets with. You *must* make this path absolute if you are going to be using critical in multiple target files in disparate directory depths. (eg. targeting both `/index.html` and `/admin/index.html` would require this path to start with `/` or it wouldn't work.)
 
 
 ## CLI

--- a/index.js
+++ b/index.js
@@ -146,8 +146,8 @@ exports.generate = function (opts, cb) {
                     // create path relative to opts.base
                     var relativeToBase = path.relative(path.resolve(opts.base), path.resolve(path.join(dir, filePath)));
 
-                    // prepend / to make it absolute
-                    return normalizePath(match.replace(filePath, path.join('/', relativeToBase)));
+                    var pathPrefix = (typeof opts.pathPrefix === "undefined") ? "/" : opts.pathPrefix;
+                    return normalizePath(match.replace(filePath, path.join(pathPrefix, relativeToBase)));
                 });
             });
 

--- a/test/02-generate.js
+++ b/test/02-generate.js
@@ -155,7 +155,22 @@ describe('Module - generate', function () {
             height: 900,
             inlineImages: true
         }, assertCritical(target, expected, done));
+    });
 
+    it('should respect pathPrefix', function (done) {
+        var expected = read('expected/path-prefix.css');
+        var target = 'path-prefix.css';
 
+        critical.generate({
+            base: 'fixtures/',
+            src: 'path-prefix.html',
+            css: [
+                'fixtures/styles/path-prefix.css'
+            ],
+            dest: target,
+            width: 1300,
+            height: 900,
+            pathPrefix: ''//empty string most likely to candidate for failure if change in code results in checking option lazily
+        }, assertCritical(target, expected, done));
     });
 });

--- a/test/expected/path-prefix.css
+++ b/test/expected/path-prefix.css
@@ -1,0 +1,3 @@
+.header {
+    background: transparent url('images/critical.png');
+}

--- a/test/fixtures/path-prefix.html
+++ b/test/fixtures/path-prefix.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html class="no-js">
+    <head>
+        <meta charset="utf-8">
+        <title>critical css test</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+    <body>
+        <div class="container">
+            <div class="header"></div>
+        </div>
+    </body>
+</html>

--- a/test/fixtures/styles/path-prefix.css
+++ b/test/fixtures/styles/path-prefix.css
@@ -1,0 +1,3 @@
+.header {
+    background: transparent url('../images/critical.png');
+}


### PR DESCRIPTION
Defaults to "/" but does not add "/" automatically since this would prevent people from using this to set paths to be relative (if you specify pathPrefix to "" it will make your paths relative paths instead of absolute).

Fixes #51 