### PR TITLE
feat(inline): allow ability to whitelist inline sources by skipping a…

### DIFF
--- a/lib/inline-styles.js
+++ b/lib/inline-styles.js
@@ -27,6 +27,9 @@ module.exports = function (html, opts) {
         dom('link').each(function (idx, el) {
             el = dom(el);
             var href = el.attr('href');
+            if (opts.css && opts.css.indexOf(href) === -1) {
+                return;
+            }
 
             if (el.attr('rel') === 'stylesheet' && isLocal(href)) {
                 var dir = base + path.dirname(href);


### PR DESCRIPTION
…ny link tags with hrefs that are not in opts.css

We have multiple link tags on the page, and don't want to inline all of them, so this is useful to us.  I wasn't 100% sure it was best to reuse to css option, but it seemed to make sense.