### PR TITLE
option to change what rel attribute is inlined in the html file

### DIFF
--- a/lib/inline-styles.js
+++ b/lib/inline-styles.js
@@ -14,6 +14,7 @@ var CleanCSS = require('clean-css');
 module.exports = function (html, opts) {
     var base = opts.base || process.cwd();
     var minify = opts.minify;
+    var rel = opts.rel || 'stylesheet';
     var maxImageSize = opts.maxImageFileSize || 10240;
     var dom = cheerio.load(String(html),{
         decodeEntities: false
@@ -28,7 +29,7 @@ module.exports = function (html, opts) {
             el = dom(el);
             var href = el.attr('href');
 
-            if (el.attr('rel') === 'stylesheet' && isLocal(href)) {
+            if (el.attr('rel') === rel && isLocal(href)) {
                 var dir = base + path.dirname(href);
                 var file = path.join(base, href);
                 var style = fs.readFileSync(file);


### PR DESCRIPTION
right now it inlines every rel="stylesheet" this will allow for a custom rel attribute to be inlined

https://github.com/brianmontana/montana-style/blob/master/app/index.html

Hoping this will clear up when using a noscript fallback for the main css