### PR TITLE
Stream: Actually Emit Critical's Errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ exports.stream = function (opts) {
 
         exports.generate(options, function (err, data) {
             if (err) {
-                return new PluginError('critical', err.message);
+                return cb(new PluginError('critical', err.message));
             }
 
             // rename file if not inlined


### PR DESCRIPTION
Returning the error does nothing, it needs to be given to the callback and thus emitted in the stream.

Now, errors from critical will crash the stream and gulp will output them to the console (previously, it just exited).