### PR TITLE
explicit close stdout streams of child processes on exit 

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -130,6 +130,15 @@ function generate(opts) {
                 // What viewports do you care about?
                 width: dimensions.width,   // viewport width
                 height: dimensions.height  // viewport height
+            }, function(err, stdout) {
+                // explicit close stdout streams of child processes on exit (delegation from penthouse)
+                // see node api doc #child_process_event_exit
+                //err.debug is also given, please forward it to console.log if a debug flag was set ...
+                var childProcessStdout = (err || {}).stdout || stdout;
+
+                if(typeof childProcessStdout.destroy === 'function'){
+                    childProcessStdout.destroy();
+                }
             });
         });
     }).then(function (criticalCSS) {


### PR DESCRIPTION
Some weird stuff: test are failing for 'Module - generate', because of the added callback, maybe some problem with the promise wrapping? Tried to wrap the callback in a promise too, but that did not work out as intended. 
