### PR TITLE
remove uncaughtException listener and related functions

### DIFF
--- a/lib/gc.js
+++ b/lib/gc.js
@@ -3,7 +3,6 @@ var fs = require('fs');
 var _ = require('lodash');
 var debug = require('debug')('critical:gc');
 var files = [];
-var handleException = true;
 
 function cleanup() {
     files = _.uniq(files);
@@ -23,7 +22,6 @@ function cleanup() {
 function onExit() {
     process.emit('cleanup');
     process.removeListener('cleanup', cleanup);
-    process.removeListener('uncaughtException', onException);
     process.removeListener('SIGINT', onSigInt);
     process.removeListener('exit', onExit);
 }
@@ -31,23 +29,10 @@ function onExit() {
 function onSigInt() {
     process.exit(2);
 }
-
-function onException(exception) {
-    if (handleException) {
-        console.error(exception);
-        return process.exit(99);
-    }
-}
-
 process.on('SIGINT', onSigInt);
 process.on('cleanup', cleanup);
 process.on('exit', onExit);
-process.on('uncaughtException', onException);
 
 module.exports.addFile = function (file) {
     files.push(file);
-};
-
-module.exports.skipExceptions = function () {
-    handleException = false;
 };

--- a/test/02-generate.js
+++ b/test/02-generate.js
@@ -7,11 +7,9 @@ var assert = require('chai').assert;
 var async = require('async');
 var finalhandler = require('finalhandler');
 var serveStatic = require('serve-static');
-var gc = require('../lib/gc');
 var critical = require('../');
 var read = require('./helper/testhelper').read;
 var assertCritical = require('./helper/testhelper').assertCritical;
-gc.skipExceptions();
 
 process.chdir(path.resolve(__dirname));
 process.setMaxListeners(0);

--- a/test/03-inline.js
+++ b/test/03-inline.js
@@ -1,11 +1,9 @@
 /* eslint-env node, mocha */
 'use strict';
 var path = require('path');
-var gc = require('../lib/gc');
 var critical = require('../');
 var read = require('./helper/testhelper').read;
 var assertCritical = require('./helper/testhelper').assertCritical;
-gc.skipExceptions();
 
 process.chdir(path.resolve(__dirname));
 process.setMaxListeners(0);

--- a/test/04-generateInline.js
+++ b/test/04-generateInline.js
@@ -4,12 +4,10 @@ var path = require('path');
 var assert = require('chai').assert;
 var async = require('async');
 var nn = require('normalize-newline');
-var gc = require('../lib/gc');
 var critical = require('../');
 var read = require('./helper/testhelper').read;
 var readAndRemove = require('./helper/testhelper').readAndRemove;
 var assertCritical = require('./helper/testhelper').assertCritical;
-gc.skipExceptions();
 
 process.chdir(path.resolve(__dirname));
 process.setMaxListeners(0);

--- a/test/05-cli.js
+++ b/test/05-cli.js
@@ -12,8 +12,6 @@ var nn = require('normalize-newline');
 var finalhandler = require('finalhandler');
 var serveStatic = require('serve-static');
 var skipWin = process.platform === 'win32' ? it.skip : it;
-var gc = require('../lib/gc');
-gc.skipExceptions();
 
 process.chdir(path.resolve(__dirname));
 process.setMaxListeners(0);

--- a/test/06-streams.js
+++ b/test/06-streams.js
@@ -12,10 +12,8 @@ var gutil = require('gulp-util');
 var array = require('stream-array');
 var nn = require('normalize-newline');
 
-var gc = require('../lib/gc');
 var critical = require('../');
 var read = require('./helper/testhelper').read;
-gc.skipExceptions();
 
 process.chdir(path.resolve(__dirname));
 process.setMaxListeners(0);


### PR DESCRIPTION
In addition to issue #133, this removes the uncaughtException handler altogether. Errors will cause the process to exit (with code 1 instead of 99), triggering the exit event which, in turn, triggers a cleanup.