### PR TITLE
Ignore 404 requests, reject promise with Error not String

### DIFF
--- a/lib/fileHelper.js
+++ b/lib/fileHelper.js
@@ -95,7 +95,7 @@ function requestAsync(uri) {
             if (resp.statusCode !== 200) {
                 return reject(new Error('Wrong status code ' + resp.statusCode + ' for ' + uri));
             }
-            
+
             resolve(resp);
         });
     });

--- a/lib/fileHelper.js
+++ b/lib/fileHelper.js
@@ -86,7 +86,7 @@ function requestAsync(uri) {
             if (err) {
                 return reject(err);
             }
-            if (resp.statusCode === 403 || resp.statusCode == 404) {
+            if (resp.statusCode === 403 || resp.statusCode === 404) {
                 console.log('Ignoring', uri, '(' + resp.statusCode + ')');
                 resp.body = '';
                 return resolve(resp);

--- a/lib/fileHelper.js
+++ b/lib/fileHelper.js
@@ -86,15 +86,16 @@ function requestAsync(uri) {
             if (err) {
                 return reject(err);
             }
-            if (resp.statusCode === 403) {
-                console.log('Ignoring', uri, '(403 Forbidden)');
+            if (resp.statusCode === 403 || resp.statusCode == 404) {
+                console.log('Ignoring', uri, '(' + resp.statusCode + ')');
                 resp.body = '';
                 return resolve(resp);
             }
 
             if (resp.statusCode !== 200) {
-                return reject('Wrong status code ' + resp.statusCode + ' for ' + uri);
+                return reject(new Error('Wrong status code ' + resp.statusCode + ' for ' + uri));
             }
+            
             resolve(resp);
         });
     });

--- a/test/02-generate.js
+++ b/test/02-generate.js
@@ -60,6 +60,19 @@ describe('Module - generate', function () {
         }, assertCritical(target, expected, done));
     });
 
+    it('should ignore stylesheets blocked due to 404', function (done) {
+        var expected = '\n';
+        var target = '.404.css';
+
+        critical.generate({
+            base: 'fixtures/',
+            src: '404-css.html',
+            dest: target,
+            width: 1300,
+            height: 900
+        }, assertCritical(target, expected, done));
+    });
+
     it('should generate multi-dimension critical-path CSS', function (done) {
         var expected = read('expected/generate-adaptive.css', 'utf8');
         var target = '.adaptive.css';

--- a/test/fixtures/404-css.html
+++ b/test/fixtures/404-css.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+    <link href="//cloud.typography.com/6020032/784002/css/404.css" rel='stylesheet' />
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
Hey guys, two changes here.

The first is straightforward — promises should be rejected with an Error and not a String (this was yielding warnings).

Secondly, I think it's best to ignore 404 responses as well as 403. My main reason for doing this is that we're using remote critical generation (via URL, e.g. `/about`), but the pages referenced include the actual critical CSS that is about to be generated (e.g. `/css/about-critical.css`). Of course, it's not yet generated (since that's what we're doing) and it errors.

However, I also think that generation shouldn't stop just because one resource can't be found. A different solution would be including an option for this on initialisation.

Let me know what you think.