### PR TITLE
add support for link preload hrefs

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -93,7 +93,12 @@ function generate(opts) {
             }
 
             // Oust extracts a list of your stylesheets
-            var stylesheets = oust(html.toString(), 'stylesheets').map(file.resourcePath(opts));
+            var stylesheets = [
+                oust(html.toString(), 'stylesheets'),
+                oust(html.toString(), 'preload')
+            ].reduce(function (a, b) {
+                return a.concat(b);
+            }, []).map(file.resourcePath(opts));
             debug('Stylesheets: ' + stylesheets);
             return Promise.map(stylesheets, file.assertLocal(opts));
             // read files

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "meow": "^3.3.0",
     "mime-types": "^2.1.6",
     "object-assign": "^4.0.1",
-    "oust": "^0.2.3",
+    "oust": "git://github.com/akrawchyk/oust",
     "parseurl": "^1.3.0",
     "penthouse": "^0.9.2",
     "postcss": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "meow": "^3.3.0",
     "mime-types": "^2.1.6",
     "object-assign": "^4.0.1",
-    "oust": "git://github.com/akrawchyk/oust",
+    "oust": "^0.3.0",
     "parseurl": "^1.3.0",
     "penthouse": "^0.9.2",
     "postcss": "^5.0.5",

--- a/test/05-cli.js
+++ b/test/05-cli.js
@@ -49,7 +49,7 @@ describe('CLI', function () {
 
             var expected = fs.readFileSync(path.join(__dirname, 'expected/generate-default.css'), 'utf8');
             cp.stdout.on('data', function (data) {
-                assert.strictEqual(nn(data), nn(expected));
+                assert.strictEqual(nn(data.toString()), nn(expected));
                 done();
             });
         });
@@ -60,7 +60,7 @@ describe('CLI', function () {
 
             var expected = fs.readFileSync(path.join(__dirname, 'expected/generate-default.css'), 'utf8');
             cp.stdout.on('data', function (data) {
-                assert.strictEqual(nn(data), nn(expected));
+                assert.strictEqual(nn(data.toString()), nn(expected));
                 done();
             });
         });
@@ -103,7 +103,7 @@ describe('CLI', function () {
 
             var expected = fs.readFileSync(path.join(__dirname, 'expected/generate-default.css'), 'utf8');
             cp.stdout.on('data', function (data) {
-                assert.strictEqual(nn(data), nn(expected));
+                assert.strictEqual(nn(data.toString()), nn(expected));
                 done();
             });
         });


### PR DESCRIPTION
This PR adds support for `rel="preload"` stylesheet links as specified here https://w3c.github.io/preload/.

It's useful for implementing the preload pattern with [loadCSS](https://github.com/filamentgroup/loadCSS#recommended-usage-pattern).