### PR TITLE
add support for the penthouse strict option

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ critical.generate({
 | assetPaths       | `array`       | `[]` | List of directories/urls where the inliner should start looking for assets
 | maxImageFileSize | `integer`     | `10240`| Sets a max file size (in bytes) for base64 inlined images
 | timeout          | `integer`     | `30000`| Sets a maximum timeout for the operation
-| strict           | `boolean`      | `false`| Set to true to throw on css errors (will run faster if no errors)
+| strict           | `boolean`     | `false`| Set to true to throw on css errors (will run faster if no errors)
 | pathPrefix       | `string`      | `/` | Path to prepend CSS assets with. You *must* make this path absolute if you are going to be using critical in multiple target files in disparate directory depths. (eg. targeting both `/index.html` and `/admin/index.html` would require this path to start with `/` or it wouldn't work.)
 | include          | `array`       | `[]` | Force include css rules. See [`penthouse#usage`](https://github.com/pocketjoso/penthouse#usage-1).
 | ignore           | `array`       | `[]` | Ignore css rules. See [`filter-css`](https://github.com/bezoerb/filter-css) for usage examples.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ critical.generate({
     // Complete Timeout for Operation
     timeout: 30000,
 
+    // Set to true to throw on css errors (will run faster if no errors)
+    timeout: 30000,
+
     // Prefix for asset directory
     pathPrefix: '/MySubfolderDocrot',
 
@@ -223,6 +226,7 @@ critical.generate({
 | assetPaths       | `array`       | `[]` | List of directories/urls where the inliner should start looking for assets
 | maxImageFileSize | `integer`     | `10240`| Sets a max file size (in bytes) for base64 inlined images
 | timeout          | `integer`     | `30000`| Sets a maximum timeout for the operation
+| strict           | `boolean`      | `false`| Set to true to throw on css errors (will run faster if no errors)
 | pathPrefix       | `string`      | `/` | Path to prepend CSS assets with. You *must* make this path absolute if you are going to be using critical in multiple target files in disparate directory depths. (eg. targeting both `/index.html` and `/admin/index.html` would require this path to start with `/` or it wouldn't work.)
 | include          | `array`       | `[]` | Force include css rules. See [`penthouse#usage`](https://github.com/pocketjoso/penthouse#usage-1).
 | ignore           | `array`       | `[]` | Ignore css rules. See [`filter-css`](https://github.com/bezoerb/filter-css) for usage examples.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ critical.generate({
     timeout: 30000,
 
     // Set to true to throw on css errors (will run faster if no errors)
-    timeout: 30000,
+    strict: false,
 
     // Prefix for asset directory
     pathPrefix: '/MySubfolderDocrot',

--- a/cli.js
+++ b/cli.js
@@ -85,6 +85,9 @@ cli.flags = _.reduce(cli.flags, function (res, val, key) {
         case 'timeout':
             res.timeout = val;
             break;
+        case 'strict':
+            res.strict = val;
+            break;
         case 'assetpaths':
         case 'assetPaths':
             if (_.isString(val)) {

--- a/cli.js
+++ b/cli.js
@@ -30,6 +30,7 @@ var help = [
     '   --maxFileSize           Sets a max file size (in bytes) for base64 inlined images',
     '   --assetPaths            Directories/Urls where the inliner should start looking for assets.',
     '   --timeout               Sets the maximum timeout (in milliseconds) for the operation (defaults to 30000 ms).',
+    '   --strict                Set to true to throw on css errors (will run faster if no errors).',
     '   ----------------------------------------------------------------------.',
     '   Deprecated - use "--inline" to retrieve the modified HTML',
     '   critical source.html --inline > dest.html',

--- a/lib/core.js
+++ b/lib/core.js
@@ -157,6 +157,7 @@ function generate(opts) {
                     css: csspath,
                     forceInclude: opts.include || [],
                     timeout: opts.timeout,
+                    strict: opts.strict,
                     maxEmbeddedBase64Length: opts.maxImageFileSize || 10240,
                     // viewport width
                     width: dimensions.width,


### PR DESCRIPTION
This feature is being used to speed up CSS processing when there are no errors.
