### PR TITLE
Bump cli package to v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "chalk": "^1.1.1",
     "cheerio": "^0.22.0",
     "clean-css": "^3.4.8",
-    "cli": "^1.0.0",
+    "cli": "^1.0.1",
     "debug": "^2.2.0",
     "filter-css": "^0.1.0",
     "finalhandler": "^0.5.0",


### PR DESCRIPTION
💁  This change bumps the version of the `node-cli` package to version 1.0.1. This resolves a security issue.
#### Before

```
$ nsp check
(+) 1 vulnerabilities found
┌───────────────┬───────────────────────────────────────────────────────┐
│               │ Arbitrary File Write                                  │
├───────────────┼───────────────────────────────────────────────────────┤
│ Name          │ cli                                                   │
├───────────────┼───────────────────────────────────────────────────────┤
│ Installed     │ 1.0.0                                                 │
├───────────────┼───────────────────────────────────────────────────────┤
│ Vulnerable    │ All                                                   │
├───────────────┼───────────────────────────────────────────────────────┤
│ Patched       │ None                                                  │
├───────────────┼───────────────────────────────────────────────────────┤
│ Path          │ critical@0.8.0 > cli@1.0.0                            │
├───────────────┼───────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/95                 │
└───────────────┴───────────────────────────────────────────────────────┘
```
#### After

```
$ nsp check
```
