### PR TITLE
If src is remote, assume stylesheets are remote. Closes #195

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ critical.generate({
 | inline           | `boolean`     | `false` | Inline critical-path CSS using filamentgroup's loadCSS  |
 | base             | `string`      | `path.dirname(src)` or `process.cwd()` | Base directory in which the source and destination are to be written |
 | html             | `string`      | | HTML source to be operated against. This option takes precedence over the `src` option |
-| src              | `string`      | | Location of the HTML source to be operated against. If it is remote and no base is provided, it is assumed that stylesheets are remote as well. |
+| src              | `string`      | | Location of the HTML source to be operated against. If it is remote and base is remote, it is assumed that stylesheets are remote as well. |
 | dest             | `string`      | | Location of where to save the output of an operation (will be relative to base if no absolute path is set) |  
 | destFolder       | `string`      | `''` | Subfolder relative to base directory. Only relevant without src (if raw html is provided) or if the destination is outside base |
 | width            | `integer`     | `900`  | Width of the target viewport |

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ critical.generate({
 | inline           | `boolean`     | `false` | Inline critical-path CSS using filamentgroup's loadCSS  |
 | base             | `string`      | `path.dirname(src)` or `process.cwd()` | Base directory in which the source and destination are to be written |
 | html             | `string`      | | HTML source to be operated against. This option takes precedence over the `src` option |
-| src              | `string`      | | Location of the HTML source to be operated against. If it is remote, it is assumed stylesheet are remote as well. |
+| src              | `string`      | | Location of the HTML source to be operated against. If it is remote and no base is provided, it is assumed that stylesheets are remote as well. |
 | dest             | `string`      | | Location of where to save the output of an operation (will be relative to base if no absolute path is set) |  
 | destFolder       | `string`      | `''` | Subfolder relative to base directory. Only relevant without src (if raw html is provided) or if the destination is outside base |
 | width            | `integer`     | `900`  | Width of the target viewport |

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ critical.generate({
 | inline           | `boolean`     | `false` | Inline critical-path CSS using filamentgroup's loadCSS  |
 | base             | `string`      | `path.dirname(src)` or `process.cwd()` | Base directory in which the source and destination are to be written |
 | html             | `string`      | | HTML source to be operated against. This option takes precedence over the `src` option |
-| src              | `string`      | | Location of the HTML source to be operated against |
+| src              | `string`      | | Location of the HTML source to be operated against. If it is remote, it is assumed stylesheet are remote as well. |
 | dest             | `string`      | | Location of where to save the output of an operation (will be relative to base if no absolute path is set) |  
 | destFolder       | `string`      | `''` | Subfolder relative to base directory. Only relevant without src (if raw html is provided) or if the destination is outside base |
 | width            | `integer`     | `900`  | Width of the target viewport |

--- a/lib/core.js
+++ b/lib/core.js
@@ -94,14 +94,11 @@ function appendStylesheets(opts) {
         var stylesheets = oust(htmlfile.contents.toString(), 'stylesheets');
         debug('Stylesheets: ' + stylesheets);
 
-        // If src is external and no base is provided, then all stylesheets should be external
-        if (opts.src && !opts.base && file.isExternal(opts.src)) {
-            urlObject = url.parse(opts.src);
+        // If src is external and base is external, then all stylesheets should be external
+        if (opts.src && file.isExternal(opts.base) && file.isExternal(opts.src)) {
 
-            // url.host includes port
-            baseUrl = urlObject.protocol + '//' + urlObject.host;
             stylesheets = stylesheets.map(function (stylesheet) {
-                return file.isExternal(stylesheet) ? stylesheet : baseUrl + stylesheet;
+                return file.isExternal(stylesheet) ? stylesheet : opts.base + stylesheet;
             });
         }
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -2,6 +2,7 @@
 var fs = require('fs');
 var os = require('os');
 var path = require('path');
+var url = require('url');
 var http = require('http');
 var _ = require('lodash');
 var penthouse = require('penthouse');
@@ -81,6 +82,8 @@ function startServer(opts) {
  */
 function appendStylesheets(opts) {
     return function (htmlfile) {
+        var baseUrl;
+        var urlObject;
         // consider opts.css and map to array if it's a string
         if (opts.css) {
             htmlfile.stylesheets = typeof opts.css === 'string' ? [opts.css] : opts.css;
@@ -90,6 +93,18 @@ function appendStylesheets(opts) {
         // Oust extracts a list of your stylesheets
         var stylesheets = oust(htmlfile.contents.toString(), 'stylesheets');
         debug('Stylesheets: ' + stylesheets);
+
+        // If src is external, then all stylesheets should be external
+        if (opts.src && file.isExternal(opts.src)) {
+            urlObject = url.parse(opts.src);
+
+            // url.host includes port
+            baseUrl = urlObject.protocol + '//' + urlObject.host;
+            stylesheets = stylesheets.map(function(stylesheet) {
+                return baseUrl + stylesheet;
+            });
+        }
+
         stylesheets = stylesheets.map(file.resourcePath(htmlfile, opts));
         return Bluebird.map(stylesheets, file.assertLocal(opts)).then(function (stylesheets) {
             htmlfile.stylesheets = stylesheets;

--- a/lib/core.js
+++ b/lib/core.js
@@ -2,7 +2,6 @@
 var fs = require('fs');
 var os = require('os');
 var path = require('path');
-var url = require('url');
 var http = require('http');
 var _ = require('lodash');
 var penthouse = require('penthouse');
@@ -82,8 +81,6 @@ function startServer(opts) {
  */
 function appendStylesheets(opts) {
     return function (htmlfile) {
-        var baseUrl;
-        var urlObject;
         // consider opts.css and map to array if it's a string
         if (opts.css) {
             htmlfile.stylesheets = typeof opts.css === 'string' ? [opts.css] : opts.css;
@@ -96,7 +93,6 @@ function appendStylesheets(opts) {
 
         // If src is external and base is external, then all stylesheets should be external
         if (opts.src && file.isExternal(opts.base) && file.isExternal(opts.src)) {
-
             stylesheets = stylesheets.map(function (stylesheet) {
                 return file.isExternal(stylesheet) ? stylesheet : opts.base + stylesheet;
             });

--- a/lib/core.js
+++ b/lib/core.js
@@ -101,7 +101,7 @@ function appendStylesheets(opts) {
             // url.host includes port
             baseUrl = urlObject.protocol + '//' + urlObject.host;
             stylesheets = stylesheets.map(function(stylesheet) {
-                return baseUrl + stylesheet;
+                return file.isExternal(stylesheet) ? stylesheet : baseUrl + stylesheet;
             });
         }
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -94,8 +94,8 @@ function appendStylesheets(opts) {
         var stylesheets = oust(htmlfile.contents.toString(), 'stylesheets');
         debug('Stylesheets: ' + stylesheets);
 
-        // If src is external, then all stylesheets should be external
-        if (opts.src && file.isExternal(opts.src)) {
+        // If src is external and no base is provided, then all stylesheets should be external
+        if (opts.src && !opts.base && file.isExternal(opts.src)) {
             urlObject = url.parse(opts.src);
 
             // url.host includes port

--- a/lib/core.js
+++ b/lib/core.js
@@ -100,7 +100,7 @@ function appendStylesheets(opts) {
 
             // url.host includes port
             baseUrl = urlObject.protocol + '//' + urlObject.host;
-            stylesheets = stylesheets.map(function(stylesheet) {
+            stylesheets = stylesheets.map(function (stylesheet) {
                 return file.isExternal(stylesheet) ? stylesheet : baseUrl + stylesheet;
             });
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "critical",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Extract & Inline Critical-path CSS from HTML",
   "author": "Addy Osmani",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixes https://github.com/addyosmani/critical/issues/195 by assuming that if src is remote, then your stylesheets will also be remote. It turn absolute stylesheet link into http links by extracting the base url from `opts.src`