### PR TITLE
If src is remote, assume stylesheets are remote. Closes #195

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ critical.generate({
 | inline           | `boolean`     | `false` | Inline critical-path CSS using filamentgroup's loadCSS  |
 | base             | `string`      | `path.dirname(src)` or `process.cwd()` | Base directory in which the source and destination are to be written |
 | html             | `string`      | | HTML source to be operated against. This option takes precedence over the `src` option |
-| src              | `string`      | | Location of the HTML source to be operated against |
+| src              | `string`      | | Location of the HTML source to be operated against. If it is remote, it is assumed that stylesheets are remote as well. |
 | dest             | `string`      | | Location of where to save the output of an operation (will be relative to base if no absolute path is set) |  
 | destFolder       | `string`      | `''` | Subfolder relative to base directory. Only relevant without src (if raw html is provided) or if the destination is outside base |
 | width            | `integer`     | `900`  | Width of the target viewport |

--- a/lib/core.js
+++ b/lib/core.js
@@ -2,6 +2,7 @@
 var fs = require('fs');
 var os = require('os');
 var path = require('path');
+var url = require('url');
 var http = require('http');
 var _ = require('lodash');
 var penthouse = require('penthouse');
@@ -81,6 +82,8 @@ function startServer(opts) {
  */
 function appendStylesheets(opts) {
     return function (htmlfile) {
+        var baseUrl;
+        var urlObject;
         // consider opts.css and map to array if it's a string
         if (opts.css) {
             htmlfile.stylesheets = typeof opts.css === 'string' ? [opts.css] : opts.css;
@@ -90,6 +93,18 @@ function appendStylesheets(opts) {
         // Oust extracts a list of your stylesheets
         var stylesheets = oust(htmlfile.contents.toString(), 'stylesheets');
         debug('Stylesheets: ' + stylesheets);
+
+        // If src is external and base is external, then all stylesheets should be external
+        if (opts.src && file.isExternal(opts.src)) {
+            urlObject = url.parse(opts.src);
+
+            // url.host includes port
+            baseUrl = urlObject.protocol + '//' + urlObject.host;
+            stylesheets = stylesheets.map(function (stylesheet) {
+                return file.isExternal(stylesheet) ? stylesheet : url.resolve(baseUrl, stylesheet);
+            });
+        }
+
         stylesheets = stylesheets.map(file.resourcePath(htmlfile, opts));
         return Bluebird.map(stylesheets, file.assertLocal(opts)).then(function (stylesheets) {
             htmlfile.stylesheets = stylesheets;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "critical",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Extract & Inline Critical-path CSS from HTML",
   "author": "Addy Osmani",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixes https://github.com/addyosmani/critical/pull/195 by checking if `opts.src` is remote. If it is remote, then it assumes all stylesheets are also remote.