### PR TITLE
Support for passing CSS files as Vinyl objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ critical.generate({
 | src              | `string`      | | Location of the HTML source to be operated against |
 | dest             | `string`      | | Location of where to save the output of an operation (will be relative to base if no absolute path is set) |  
 | destFolder       | `string`      | `''` | Subfolder relative to base directory. Only relevant without src (if raw html is provided) or if the destination is outside base |
+| css              | `array`       | | An array of paths to css files, or an array of [Vinyl](https://www.npmjs.com/package/vinyl) file objects.
 | width            | `integer`     | `900`  | Width of the target viewport |
 | height           | `integer`     | `1300` | Height of the target viewport |
 | dimensions       | `array`       | `[]` | An array of objects containing height and width. Takes precedence over `width` and `height` if set

--- a/lib/core.js
+++ b/lib/core.js
@@ -82,9 +82,9 @@ function startServer(opts) {
  */
 function appendStylesheets(opts) {
     return function (htmlfile) {
-        // consider opts.css and map to array if it's a string
+        // consider opts.css and map to array if it isn't one
         if (opts.css) {
-            htmlfile.stylesheets = typeof opts.css === 'string' ? [opts.css] : opts.css;
+            htmlfile.stylesheets = Array.isArray(opts.css) ? opts.css : [opts.css];
             return htmlfile;
         }
 
@@ -149,6 +149,9 @@ function inlineImages(opts) {
  */
 function vinylize(opts) {
     return function (filepath) {
+        if (filepath._isVinyl) {
+            return filepath;
+        }
         debug('vinylize', path.resolve(filepath));
         return file.getVinylPromise({
             src: path.resolve(filepath),

--- a/test/02-generate.js
+++ b/test/02-generate.js
@@ -2,11 +2,13 @@
 'use strict';
 var path = require('path');
 var http = require('http');
+var fs = require('fs');
 var nn = require('normalize-newline');
 var assert = require('chai').assert;
 var async = require('async');
 var finalhandler = require('finalhandler');
 var serveStatic = require('serve-static');
+var Vinyl = require('vinyl');
 var critical = require('../');
 var read = require('./helper/testhelper').read;
 var assertCritical = require('./helper/testhelper').assertCritical;
@@ -26,6 +28,29 @@ describe('Module - generate', function () {
             base: 'fixtures/',
             src: 'generate-default.html',
             dest: target,
+            width: 1300,
+            height: 900
+        }, assertCritical(target, expected, done));
+    });
+
+    it('should generate critical-path CSS from CSS files passed as Vinyl objects', function (done) {
+        var expected = read('expected/generate-default.css');
+        var target = path.resolve('.critical.css');
+        var stylesheets = ['fixtures/styles/main.css', 'fixtures/styles/bootstrap.css']
+            .map(function (filePath) {
+                return new Vinyl({
+                    cwd: '/',
+                    base: '/fixtures/',
+                    path: filePath,
+                    contents: Buffer.from(fs.readFileSync(path.join(__dirname, filePath), 'utf8'), 'utf8')
+                });
+            });
+
+        critical.generate({
+            base: 'fixtures/',
+            src: 'generate-default-nostyle.html',
+            dest: target,
+            css: stylesheets,
             width: 1300,
             height: 900
         }, assertCritical(target, expected, done));


### PR DESCRIPTION
Critical can now process CSS files passed to the library as an array of Vinyl file objects in `opts.css`, so they do not need to be written to disk before processing.

This consists of two very small changes.
1: `core.vinylize` now checks if parameter `filepath` is already a Vinyl file before attempting to make a Vinyl file out of it.  If `filepath` is already a Vinyl file, just return it.

2: `core.appendStylesheets` now checks if `opts.css` is an array before converting it to an array. Previously, it checked if `opts.css` was a string.

I was going to update `README.md` to reflect that `opts.css` could be a Vinyl file, an array of Vinyl files, a string, or an array of strings, but it seems `opts.css` is not documented there at all. I can add it to the table, but I didn't know if this was intentional.