### PR TITLE
Fix underlying shared fs.read array

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -337,7 +337,8 @@ function getVinylPromise(opts) {
             }
 
             return fs.readFileAsync(file.path).then(function (contents) {
-                file.contents = contents;
+                //  Multiple calls to the fs methods can result in Buffers that return a shared single underlying ArrayBuffer
+                file.contents = Array.isArray(contents) ? contents.pop() : contents;
                 return file;
             });
         });

--- a/test/02-generate.js
+++ b/test/02-generate.js
@@ -36,9 +36,9 @@ describe('Module - generate', function () {
     it('should generate critical-path CSS for multiple calls', function (done) {
         var source = ['generate-default.html', 'generate-default2.html'];
         var expected = read('expected/generate-default.css');
-        var target = path.resolve('.critical.css');
 
-        async.each(source, function (file, callback) {
+        async.forEachOf(source, function (file, val, callback) {
+            var target = path.resolve('.critical' + val + '.css');
             critical.generate({
                 base: 'fixtures/',
                 src: file,

--- a/test/02-generate.js
+++ b/test/02-generate.js
@@ -33,12 +33,11 @@ describe('Module - generate', function () {
         }, assertCritical(target, expected, done));
     });
 
-    it('should generate critical-path CSS for multiple files in loop', function (done) {
+    it('should generate critical-path CSS for multiple calls', function (done) {
         var source = ['generate-default.html', 'generate-default2.html'];
         var expected = read('expected/generate-default.css');
         var target = path.resolve('.critical.css');
 
-        // assuming openFiles is an array of file names
         async.each(source, function (file, callback) {
             critical.generate({
                 base: 'fixtures/',

--- a/test/02-generate.js
+++ b/test/02-generate.js
@@ -33,6 +33,27 @@ describe('Module - generate', function () {
         }, assertCritical(target, expected, done));
     });
 
+    it('should generate critical-path CSS for multiple files in loop', function (done) {
+        var source = ['generate-default.html', 'generate-default2.html'];
+        var expected = read('expected/generate-default.css');
+        var target = path.resolve('.critical.css');
+
+        // assuming openFiles is an array of file names
+        async.each(source, function (file, callback) {
+            critical.generate({
+                base: 'fixtures/',
+                src: file,
+                dest: target,
+                width: 1300,
+                height: 900
+            }, assertCritical(target, expected, callback));
+        }, function (err) {
+            if (!err) {
+                done();
+            }
+        });
+    });
+
     it('should generate critical-path CSS from CSS files passed as Vinyl objects', function (done) {
         var expected = read('expected/generate-default.css');
         var target = path.resolve('.critical.css');

--- a/test/fixtures/generate-default2.html
+++ b/test/fixtures/generate-default2.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html class="no-js">
+    <head>
+        <meta charset="utf-8">
+        <title>critical css test</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+        <!-- build:css styles/main.css -->
+        <link rel="stylesheet" href="styles/main.css">
+        <link rel="stylesheet" href="styles/bootstrap.css" />
+        <!-- endbuild -->
+
+    </head>
+    <body>
+        <!--[if lt IE 10]>
+            <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+        <![endif]-->
+
+        <div class="container">
+            <div class="header">
+                <ul class="nav nav-pills pull-right">
+                    <li class="active"><a href="#">Home</a></li>
+                    <li><a href="#">About</a></li>
+                    <li><a href="#">Contact</a></li>
+                </ul>
+                <h3 class="text-muted">critical css test</h3>
+            </div>
+
+            <div class="jumbotron">
+                <h1>'Allo, 'Allo!</h1>
+                <p class="lead">Always a pleasure scaffolding your apps.</p>
+                <p><a class="btn btn-lg btn-success" href="#">Splendid!</a></p>
+            </div>
+
+            <div class="row marketing">
+                <div class="col-lg-6">
+                    <h4>HTML5 Boilerplate</h4>
+                    <p>HTML5 Boilerplate is a professional front-end template for building fast, robust, and adaptable web apps or sites.</p>
+
+                    <h4>Bootstrap</h4>
+                    <p>Sleek, intuitive, and powerful mobile first front-end framework for faster and easier web development.</p>
+                </div>
+            </div>
+
+            <div class="footer">
+                <p>♥ from the Yeoman team</p>
+            </div>
+        </div>
+
+        <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
+        <script>
+            (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
+            function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
+            e=o.createElement(i);r=o.getElementsByTagName(i)[0];
+            e.src='//www.google-analytics.com/analytics.js';
+            r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
+            ga('create','UA-XXXXX-X');ga('send','pageview');
+        </script>
+
+        <!-- build:js scripts/vendor.js -->
+        <!-- bower:js -->
+        <script src="../old/fixture/bower_components/jquery/dist/jquery.js"></script>
+        <script src="../old/fixture/bower_components/bootstrap/dist/js/bootstrap.js"></script>
+        <!-- endbower -->
+        <!-- endbuild -->
+
+        <!-- build:js scripts/plugins.js -->
+        <script src="../old/fixture/bower_components/bootstrap/js/affix.js"></script>
+        <script src="../old/fixture/bower_components/bootstrap/js/alert.js"></script>
+        <script src="../old/fixture/bower_components/bootstrap/js/dropdown.js"></script>
+        <script src="../old/fixture/bower_components/bootstrap/js/tooltip.js"></script>
+        <script src="../old/fixture/bower_components/bootstrap/js/modal.js"></script>
+        <script src="../old/fixture/bower_components/bootstrap/js/transition.js"></script>
+        <script src="../old/fixture/bower_components/bootstrap/js/button.js"></script>
+        <script src="../old/fixture/bower_components/bootstrap/js/popover.js"></script>
+        <script src="../old/fixture/bower_components/bootstrap/js/carousel.js"></script>
+        <script src="../old/fixture/bower_components/bootstrap/js/scrollspy.js"></script>
+        <script src="../old/fixture/bower_components/bootstrap/js/collapse.js"></script>
+        <script src="../old/fixture/bower_components/bootstrap/js/tab.js"></script>
+        <!-- endbuild -->
+
+        <!-- build:js scripts/main.js -->
+        <script src="../old/fixture/scripts/main.js"></script>
+        <!-- endbuild -->
+</body>
+</html>


### PR DESCRIPTION
**About**

Quick fix to the to a underline is issue where if you run critical in a loop, recursive function or through gulp can cause this error.
```error
Unhandled rejection Error: Error: File.contents can only be a Buffer, a Stream, or null.
```
The reason for this is that when multiple calls to node `fs` methods in our case `fs.readFileAsync` are made this can result in `Buffers` that share a single underlying `ArrayBuffer`. So basically if you look here ..  https://github.com/addyosmani/critical/blob/master/lib/file-helper.js#L340 
we where trying to assign a array to the file.content which is why this error was appearing.

This is a vey small noice error, that probably rarely happens, but an issue is still is. 

I added a small test that runs the critical in a loop twice this is not really sufficient as in my local case I was running critical over dozens of pages. 

If you see here my production build I have run it on a few of my files which works perfect unlike before.

![image](https://user-images.githubusercontent.com/15271739/27695191-17914504-5ce6-11e7-8f9a-34de48f214b1.png)

=========================================================

Ps. If you need any help on an issues I am more than happy to help

