### PR TITLE
Removed deprecated dependency gulp-util. Closes #274

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ const chalk = require('chalk');
 const sourceInliner = require('inline-critical');
 const Bluebird = require('bluebird');
 const through2 = require('through2');
-const PluginError = require('gulp-util').PluginError;
-const replaceExtension = require('gulp-util').replaceExtension;
+const PluginError = require('plugin-error');
+const replaceExtension = require('replace-ext');
 
 const core = require('./lib/core');
 const file = require('./lib/file-helper');

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "get-port": "^3.1.0",
     "get-stdin": "^5.0.1",
     "group-args": "^0.1.0",
-    "gulp-util": "^3.0.8",
     "imageinliner": "^0.2.4",
     "indent-string": "^3.1.0",
     "inline-critical": "^3.0.0",
@@ -46,14 +45,16 @@
     "oust": "^0.4.0",
     "parseurl": "^1.3.1",
     "penthouse": "^1.0.0",
+    "plugin-error": "^1.0.1",
     "postcss": "^6.0.4",
     "postcss-image-inliner": "^1.0.4",
+    "replace-ext": "^1.0.0",
     "request": "^2.79.0",
     "slash": "^1.0.0",
     "tempfile": "^2.0.0",
     "through2": "^2.0.3",
     "tmp": "0.0.33",
-    "vinyl": "^2.0.1"
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "async": "^2.1.4",

--- a/test/04-streams.js
+++ b/test/04-streams.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const assert = require('chai').assert;
 const vinylStream = require('vinyl-source-stream');
 const streamAssert = require('stream-assert');
-const gutil = require('gulp-util');
+const Vinyl = require('vinyl');
 const array = require('stream-array');
 const nn = require('normalize-newline');
 
@@ -27,7 +27,7 @@ function getVinyl() {
 
     function create(filepath) {
         const file = path.join(__dirname, 'fixtures', filepath);
-        return new gutil.File({
+        return new Vinyl({
             cwd: __dirname,
             base: path.dirname(file),
             path: file,


### PR DESCRIPTION
Replaced `gulp-util` with `plugin-error`, `replace-ext`, and `vinyl`.