### PR TITLE
docs: package.json `devDependencies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Critical extracts & inlines critical-path (above-the-fold) CSS from HTML
 ## Install
 
 ```
-$ npm install --save critical
+$ npm install --save-dev critical
 ```
 
 ## Build plugins


### PR DESCRIPTION
I think we should leave this as a dev dependency.
The magic happens on server and remain there :)

What do you think?