### PR TITLE
Dirty way to add support for specifying a user agent

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -137,9 +137,17 @@ function requestAsync(uri, secure = true, {user, pass} = {}) {
 
     debug(`Fetching resource: ${resourceUrl}`);
     const options = {rejectUnauthorized: false};
-    if (user && pass) {
-        options.headers = {Authorization: 'Basic ' + token(user, pass)};
+
+    options.headers = {};
+
+    if (process.env.USER_AGENT) {
+        options.headers['User-Agent'] = process.env.USER_AGENT;
     }
+
+    if (user && pass) {
+        options.headers.Authorization = 'Basic ' + token(user, pass);
+    }
+
     return got(resourceUrl, options).catch(err => {
         if (secure) {
             debug(`${err.message} - trying again over http`);


### PR DESCRIPTION
Fix for issue #303 
I guess it will be better if we had a dedicated option to do this, but this does the job as well.