### PR TITLE
Fix Support for Gulp 3 Streams

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -349,7 +349,7 @@ async function fetch(uri, options = {}, secure = true) {
  * @returns {[string]} Stylesheet urls from document source
  */
 function getStylesheetHrefs(file) {
-  if (!Vinyl.isVinyl(file)) {
+  if (!isVinyl(file)) {
     throw new Error('Parameter file needs to be a vinyl object');
   }
 
@@ -367,7 +367,7 @@ function getStylesheetHrefs(file) {
  * @returns {[string]} Asset urls from stykesheet source
  */
 function getAssets(file) {
-  if (!Vinyl.isVinyl(file)) {
+  if (!isVinyl(file)) {
     throw new Error('Parameter file needs to be a vinyl object');
   }
 


### PR DESCRIPTION
Fixes #373

I noticed there's a lovely helper that checks constructor for if `isVinyl`
https://github.com/addyosmani/critical/blob/cd3015345ccc0c693f85371627673b883485bb2d/src/file.js#L109

It appears however there are two places that were missed when adding use of this helper which can cause the stream to error out with an error when using Gulp 3:

```
Parameter file needs to be a vinyl object
```` 


