### PR TITLE
fix: remove duplicates from getStylesheetHrefs

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -356,9 +356,13 @@ function getStylesheetHrefs(file) {
   const stylesheets = oust.raw(file.contents.toString(), 'stylesheets');
   const preloads = oust.raw(file.contents.toString(), 'preload');
 
-  return [...new Set([...stylesheets, ...preloads]
-  .filter(link => link.$el.attr('media') !== 'print' && Boolean(link.value))
-  .map(link => link.value))];
+  return [
+    ...new Set(
+      [...stylesheets, ...preloads]
+        .filter(link => link.$el.attr('media') !== 'print' && Boolean(link.value))
+        .map(link => link.value)
+    ),
+  ];
 }
 
 /**

--- a/src/file.js
+++ b/src/file.js
@@ -356,9 +356,9 @@ function getStylesheetHrefs(file) {
   const stylesheets = oust.raw(file.contents.toString(), 'stylesheets');
   const preloads = oust.raw(file.contents.toString(), 'preload');
 
-  return [...stylesheets, ...preloads]
-    .filter(link => link.$el.attr('media') !== 'print' && Boolean(link.value))
-    .map(link => link.value);
+  return [...new Set([...stylesheets, ...preloads]
+  .filter(link => link.$el.attr('media') !== 'print' && Boolean(link.value))
+  .map(link => link.value))];
 }
 
 /**


### PR DESCRIPTION
## Critical produces duplicate CCSS. 

It happens when a page has duplicate link hrefs.

A typical scenario, when a `link ` is wrapped with a `noscript` critical retrieves both hrefs.

**Example:**

```HTML
<link as="style" rel="preload" onload="this.rel='stylesheet'" href="wp-includes/css/dist/block-library/style.min.css" media="all" />
<noscript>
  <link rel="stylesheet" href="wp-includes/css/dist/block-library/style.min.css" media="all" />
</noscript>
```
------

I will follow up with `file.test.js` and update `file.js` so it passes xo test.