### PR TITLE
Add back "use strict" statements.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+'use strict';
+
 const os = require('os');
 const chalk = require('chalk');
 const meow = require('meow');

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 /* eslint-disable promise/prefer-await-to-then */
 
+'use strict';
+
 const path = require('path');
 const fs = require('fs-extra');
 const through2 = require('through2');

--- a/src/array.js
+++ b/src/array.js
@@ -1,3 +1,5 @@
+'use strict';
+
 async function mapAsync(array = [], callback = a => a) {
   const result = [];
   for (const index of array.keys()) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Joi = require('@hapi/joi');
 const debug = require('debug')('critical:config');
 const {ConfigError} = require('./errors');

--- a/src/core.js
+++ b/src/core.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const {EOL} = require('os');
 const path = require('path');
 const chalk = require('chalk');

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const chalk = require('chalk');
 const {stripIndents, stripIndent} = require('common-tags');
 

--- a/src/file.js
+++ b/src/file.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const os = require('os');
 const url = require('url');

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const {mapAsync, reduceAsync, filterAsync, forEachAsync} = require('../src/array');
 
 const waitFor = ms => new Promise(resolve => setTimeout(resolve, ms));

--- a/test/blackbox.test.js
+++ b/test/blackbox.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const {createServer} = require('http');
 const getPort = require('get-port');

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const readPkgUp = require('read-pkg-up');
 const execa = require('execa');

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const {ConfigError} = require('../src/errors');
 const {getOptions, DEFAULT} = require('../src/config');
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const {createServer} = require('http');
 const getPort = require('get-port');

--- a/test/file.test.js
+++ b/test/file.test.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-await-in-loop */
 
+'use strict';
+
 const {createServer} = require('http');
 const path = require('path');
 const getPort = require('get-port');

--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const fs = require('fs-extra');
 const array = require('stream-array');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const fs = require('fs-extra');
 const vinylStream = require('vinyl-source-stream');


### PR DESCRIPTION
They are still needed.

@bezoerb: we need to enforce this in xo somehow, but I recall having trouble with it because xo prefers modules. We could live without a rule, but ideally, we should enforce it until the time has come to fully switch to mjs.

http://imaginativethinking.ca/what-the-heck-is-node-modules-strict-by-default/