### PR TITLE
[1.x] Remove `os.EOL` and use `'\n'`

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 'use strict';
-const os = require('os');
 const path = require('path');
 const chalk = require('chalk');
 const meow = require('meow');
@@ -159,7 +158,7 @@ cli.flags = reduce(cli.flags, (res, val, key) => {
 
 function error(err) {
     process.stderr.write(indentString((chalk.red('Error: ') + err.message || err), 3));
-    process.stderr.write(os.EOL);
+    process.stderr.write('\n');
     process.stderr.write(indentString(help, 3));
     process.exit(1);
 }

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,5 +1,4 @@
 'use strict';
-const os = require('os');
 const path = require('path');
 const url = require('url');
 const invokeMap = require('lodash/invokeMap');
@@ -157,7 +156,7 @@ function processStylesheets(opts) {
             .map(inlineImages(opts))
             .map(file.replaceAssetPaths(htmlfile, opts))
             .reduce((total, stylesheet) => {
-                return total + os.EOL + stylesheet.contents.toString('utf8');
+                return total + '\n' + stylesheet.contents.toString('utf8');
             }, '')
             .then(css => {
                 htmlfile.cssString = css;

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -1,5 +1,4 @@
 'use strict';
-const os = require('os');
 const url = require('url');
 const path = require('path');
 const fs = require('fs-extra');
@@ -271,7 +270,7 @@ function generateSourcePath(opts) {
                 chalk.red('Warning:'),
                 'Missing html source path. Consider \'folder\' option.',
                 'https://goo.gl/PwvFVb',
-                os.EOL
+                '\n'
             ].join(' '));
 
             opts.pathPrefix = '/';

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "get-port": "^4.2.0",
     "mocha": "^6.2.2",
     "mockery": "^2.1.0",
-    "normalize-newline": "^3.0.0",
     "read-package-json": "^2.1.0",
     "serve-static": "^1.14.1",
     "stream-array": "^1.1.2",

--- a/test/02-generate.js
+++ b/test/02-generate.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const http = require('http');
 const fs = require('fs');
-const nn = require('normalize-newline');
 const {assert} = require('chai');
 const async = require('async');
 const getPort = require('get-port');
@@ -443,8 +442,8 @@ describe('Module - generate', () => {
             }
         }, (err, results) => {
             assert.isNull(err, Boolean(err) && err);
-            assert.strictEqual(nn(results.first), nn(expected1));
-            assert.strictEqual(nn(results.second), nn(expected2));
+            assert.strictEqual(results.first, expected1);
+            assert.strictEqual(results.second, expected2);
             done();
         });
     });
@@ -968,8 +967,8 @@ describe('Module - generate (remote)', () => {
             }
         }, (err, results) => {
             assert.isNull(err, Boolean(err) && err);
-            assert.strictEqual(nn(results.first), nn(expected1));
-            assert.strictEqual(nn(results.second), nn(expected2));
+            assert.strictEqual(results.first, expected1);
+            assert.strictEqual(results.second, expected2);
             done();
         });
     });

--- a/test/03-cli.js
+++ b/test/03-cli.js
@@ -8,7 +8,6 @@ const {assert} = require('chai');
 const getPort = require('get-port');
 const mockery = require('mockery');
 const readJson = require('read-package-json');
-const nn = require('normalize-newline');
 const finalhandler = require('finalhandler');
 const serveStatic = require('serve-static');
 
@@ -56,7 +55,7 @@ describe('CLI', () => {
                     data = data.toString('utf8');
                 }
 
-                assert.strictEqual(nn(data), nn(expected));
+                assert.strictEqual(data, expected);
                 done();
             });
         });
@@ -72,7 +71,7 @@ describe('CLI', () => {
                     data = data.toString('utf8');
                 }
 
-                assert.strictEqual(nn(data), nn(expected));
+                assert.strictEqual(data, expected);
                 done();
             });
         });
@@ -83,7 +82,7 @@ describe('CLI', () => {
 
             exec(cmd, (error, stdout) => {
                 assert.isNull(error);
-                assert.strictEqual(nn(stdout.toString('utf8')), nn(expected));
+                assert.strictEqual(stdout.toString('utf8'), expected);
                 done();
             });
         });
@@ -94,7 +93,7 @@ describe('CLI', () => {
 
             exec(cmd, (error, stdout) => {
                 assert.isNull(error);
-                assert.strictEqual(nn(stdout.toString('utf8')), nn(expected));
+                assert.strictEqual(stdout.toString('utf8'), expected);
                 done();
             });
         });
@@ -105,7 +104,7 @@ describe('CLI', () => {
 
             exec(cmd, (error, stdout) => {
                 assert.isNull(error);
-                assert.strictEqual(nn(stdout.toString('utf8')), nn(expected));
+                assert.strictEqual(stdout.toString('utf8'), expected);
                 done();
             });
         });
@@ -116,7 +115,7 @@ describe('CLI', () => {
 
             exec(cmd, (error, stdout, stderr) => {
                 assert.isNull(error);
-                assert.strictEqual(nn(stdout.toString('utf8')), nn(expected));
+                assert.strictEqual(stdout.toString('utf8'), expected);
                 assert.include(stderr.toString('utf8'), 'Missing html source path. Consider \'folder\' option.');
                 done();
             });
@@ -172,7 +171,7 @@ describe('CLI', () => {
                     data = data.toString('utf8');
                 }
 
-                assert.strictEqual(nn(data), nn(expected));
+                assert.strictEqual(data, expected);
                 done();
             });
         });
@@ -199,7 +198,7 @@ describe('CLI', () => {
                     data = data.toString('utf8');
                 }
 
-                assert.strictEqual(nn(data), nn(expected));
+                assert.strictEqual(data, expected);
                 done();
             });
         });

--- a/test/04-streams.js
+++ b/test/04-streams.js
@@ -10,7 +10,6 @@ const vinylStream = require('vinyl-source-stream');
 const streamAssert = require('stream-assert');
 const Vinyl = require('vinyl');
 const array = require('stream-array');
-const nn = require('normalize-newline');
 
 const {read} = require('./helper/testhelper');
 const critical = require('..');
@@ -88,7 +87,7 @@ describe('Streams', () => {
             .pipe(streamAssert.length(1))
             .pipe(streamAssert.nth(0, d => {
                 assert.strictEqual(path.extname(d.path), '.css');
-                assert.strictEqual(nn(d.contents.toString('utf8')), expected1);
+                assert.strictEqual(d.contents.toString('utf8'), expected1);
             }))
             .pipe(streamAssert.end(done));
     });
@@ -102,7 +101,7 @@ describe('Streams', () => {
             .pipe(streamAssert.length(1))
             .pipe(streamAssert.first(d => {
                 assert.strictEqual(path.extname(d.path), '.html');
-                assert.strictEqual(nn(d.contents.toString('utf8')), expected);
+                assert.strictEqual(d.contents.toString('utf8'), expected);
             }))
             .pipe(streamAssert.end(done));
     });
@@ -123,11 +122,11 @@ describe('Streams', () => {
             .pipe(streamAssert.length(2))
             .pipe(streamAssert.nth(0, d => {
                 assert.strictEqual(path.extname(d.path), '.css');
-                assert.strictEqual(nn(d.contents.toString('utf8')), expected1);
+                assert.strictEqual(d.contents.toString('utf8'), expected1);
             }))
             .pipe(streamAssert.nth(1, d => {
                 assert.strictEqual(path.extname(d.path), '.css');
-                assert.strictEqual(nn(d.contents.toString('utf8')), expected2);
+                assert.strictEqual(d.contents.toString('utf8'), expected2);
             }))
             .pipe(streamAssert.end(done));
     });
@@ -149,7 +148,7 @@ describe('Streams', () => {
             .pipe(streamAssert.length(1))
             .pipe(streamAssert.nth(0, d => {
                 assert.strictEqual(path.extname(d.path), '.css');
-                assert.strictEqual(nn(d.contents.toString('utf8')), expected);
+                assert.strictEqual(d.contents.toString('utf8'), expected);
             }))
             .pipe(streamAssert.end(done));
     });
@@ -170,7 +169,7 @@ describe('Streams', () => {
             .pipe(streamAssert.length(1))
             .pipe(streamAssert.nth(0, d => {
                 assert.strictEqual(path.extname(d.path), '.html');
-                assert.strictEqual(nn(d.contents.toString('utf8')), expected);
+                assert.strictEqual(d.contents.toString('utf8'), expected);
             }))
             .pipe(streamAssert.end(done));
     });
@@ -190,7 +189,7 @@ describe('Streams', () => {
             .pipe(streamAssert.length(1))
             .pipe(streamAssert.nth(0, d => {
                 assert.strictEqual(path.extname(d.path), '.css');
-                assert.strictEqual(nn(d.contents.toString('utf8')), expected);
+                assert.strictEqual(d.contents.toString('utf8'), expected);
             }))
             .pipe(streamAssert.end(done));
     });
@@ -210,7 +209,7 @@ describe('Streams', () => {
             .pipe(streamAssert.length(1))
             .pipe(streamAssert.nth(0, d => {
                 assert.strictEqual(path.extname(d.path), '.html');
-                assert.strictEqual(nn(d.contents.toString('utf8')), expected);
+                assert.strictEqual(d.contents.toString('utf8'), expected);
             }))
             .pipe(streamAssert.end(done));
     });
@@ -250,7 +249,7 @@ describe('Streams', () => {
             .pipe(streamAssert.length(1))
             .pipe(streamAssert.nth(0, d => {
                 assert.strictEqual(path.extname(d.path), '.css');
-                assert.strictEqual(nn(d.contents.toString('utf8')), nn(expected));
+                assert.strictEqual(d.contents.toString('utf8'), expected);
             }))
             .pipe(streamAssert.end(done));
     });
@@ -274,7 +273,7 @@ describe('Streams', () => {
             .pipe(streamAssert.length(1))
             .pipe(streamAssert.nth(0, d => {
                 assert.strictEqual(path.extname(d.path), '.css');
-                assert.strictEqual(nn(d.contents.toString('utf8')), nn(expected));
+                assert.strictEqual(d.contents.toString('utf8'), expected);
             }))
             .pipe(streamAssert.end(done));
     });

--- a/test/helper/testhelper.js
+++ b/test/helper/testhelper.js
@@ -3,7 +3,6 @@
 const fs = require('fs');
 const path = require('path');
 const {assert} = require('chai');
-const nn = require('normalize-newline');
 
 function readAndRemove(file) {
     const testBase = path.join(__dirname, '..');
@@ -27,7 +26,7 @@ function read(file) {
         content = fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
     }
 
-    return nn(content);
+    return content;
 }
 
 /**
@@ -50,10 +49,10 @@ function assertCritical(target, expected, done, skipTarget) {
             assert.isDefined(output, 'Should produce output');
             if (!skipTarget) {
                 const dest = readAndRemove(target, true);
-                assert.strictEqual(nn(dest), nn(expected));
+                assert.strictEqual(dest, expected);
             }
 
-            assert.strictEqual(nn(output), nn(expected));
+            assert.strictEqual(output, expected);
         } catch (error) {
             done(error);
             return;


### PR DESCRIPTION
Same as #422 for 1.x