### PR TITLE
1.x: use destructuring when importing lodash

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,12 +9,7 @@ const meow = require('meow');
 const groupArgs = require('group-args');
 const indentString = require('indent-string');
 const stdin = require('get-stdin');
-const assign = require('lodash/assign');
-const reduce = require('lodash/reduce');
-const isString = require('lodash/isString');
-const isRegExp = require('lodash/isRegExp');
-const map = require('lodash/map');
-const escapeRegExp = require('lodash/escapeRegExp');
+const {assign, escapeRegExp, isString, isRegExp, map, reduce} = require('lodash');
 
 const file = require('./lib/file-helper');
 const critical = require('.');

--- a/index.js
+++ b/index.js
@@ -2,12 +2,7 @@
 
 const path = require('path');
 const fs = require('fs-extra');
-const assign = require('lodash/assign');
-const defaults = require('lodash/defaults');
-const isFunction = require('lodash/isFunction');
-const isObject = require('lodash/isObject');
-const intersection = require('lodash/intersection');
-const keys = require('lodash/keys');
+const {assign, defaults, isFunction, isObject, intersection, keys} = require('lodash');
 
 const chalk = require('chalk');
 const sourceInliner = require('inline-critical');

--- a/lib/core.js
+++ b/lib/core.js
@@ -3,10 +3,7 @@
 const os = require('os');
 const path = require('path');
 const url = require('url');
-const invokeMap = require('lodash/invokeMap');
-const assign = require('lodash/assign');
-const uniq = require('lodash/uniq');
-const flatten = require('lodash/flatten');
+const {assign, flatten, invokeMap, uniq} = require('lodash');
 const penthouse = require('penthouse');
 const CleanCSS = require('clean-css');
 const filterCss = require('filter-css');

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -4,7 +4,7 @@ const os = require('os');
 const url = require('url');
 const path = require('path');
 const fs = require('fs-extra');
-const _ = require('lodash');
+const {chain, first, map} = require('lodash');
 const Bluebird = require('bluebird');
 const got = require('got');
 const debug = require('debug')('critical:file');
@@ -261,7 +261,7 @@ function generateSourcePath(opts) {
 
         debug('generateSourcePath - links', links);
         // We can only determine a valid path by checking relative links
-        const relative = _.chain(links).omitBy(link => {
+        const relative = chain(links).omitBy(link => {
             return link.startsWith('data:') || /(?:^\/)|(?::\/\/)/.test(link);
         }).toArray().value();
 
@@ -279,12 +279,12 @@ function generateSourcePath(opts) {
             return opts.base;
         }
 
-        const dots = _.map(relative, link => {
+        const dots = map(relative, link => {
             const match = /^(\.\.\/)+/.exec(link);
-            return _.first(match);
+            return first(match);
         });
 
-        opts.pathPrefix = _.chain(dots).sortBy('length').last().value() || '';
+        opts.pathPrefix = chain(dots).sortBy('length').last().value() || '';
         debug('generateSourcePath', opts.pathPrefix.replace(/\.\./g, '~'));
     }
 

--- a/lib/gc.js
+++ b/lib/gc.js
@@ -2,13 +2,13 @@
 
 const fs = require('fs-extra');
 const exitHook = require('async-exit-hook');
-const _ = require('lodash');
+const {uniq} = require('lodash');
 const debug = require('debug')('critical:gc');
 
 let files = [];
 
 function cleanup() {
-    files = _.uniq(files);
+    files = uniq(files);
 
     if (files.length > 0) {
         debug('cleanup triggered. Unlinking temp files', files);


### PR DESCRIPTION
This should be slightly faster

Saves ~50ms from the module load time.

@bezoerb after we merge this please release a new 1.x version. We can look into #425 later