### PR TITLE
Fix undefined content type error

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -156,7 +156,7 @@ function requestAsync(uri, secure = true, opts = {}) {
         }
 
         debug(`${resourceUrl} failed: ${error.message}`);
-        return Promise.resolve(error); // eslint-disable-line promise/no-return-wrap
+        return Promise.reject(error); // eslint-disable-line promise/no-return-wrap
     });
 }
 


### PR DESCRIPTION
Attempt to fix https://github.com/addyosmani/critical/issues/414

Basically, we were calling `Promise.resolve()` with an error, when we should have called `Promise.reject()`