### PR TITLE
Remove timeout option from example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,6 @@ critical.generate({
   // Extract inlined styles from referenced stylesheets
   extract: true,
 
-  // Complete Timeout for Operation
-  timeout: 30000,
-
   // ignore CSS rules
   ignore: {
     atrule: ['@font-face'],


### PR DESCRIPTION
Since `timeout` has been removed as it is saying in [CHANGELOG](https://github.com/addyosmani/critical/blob/master/CHANGELOG.md), should be removed from README as well