### PR TITLE
Do not mutate request.method when checking file exists

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -147,7 +147,7 @@ async function fileExists(href, options = {}) {
     const {request = {}} = options;
     const method = request.method || 'head';
     try {
-      const response = await fetch(href, {...options, request});
+      const response = await fetch(href, {...options, request: {...request, method}});
       const {statusCode} = response;
 
       if (method === 'head') {

--- a/src/file.js
+++ b/src/file.js
@@ -145,12 +145,12 @@ async function fileExists(href, options = {}) {
 
   if (isRemote(href)) {
     const {request = {}} = options;
-    request.method = request.method || 'head';
+    const method = request.method || 'head';
     try {
       const response = await fetch(href, {...options, request});
       const {statusCode} = response;
 
-      if (request.method === 'head') {
+      if (method === 'head') {
         return Number.parseInt(statusCode, 10) < 400;
       }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/addyosmani/critical/issues/469.

Do not mutate the `request.method` when checking if a file exists to avoid future unwanted HEAD requests (which expects a response body).