### PR TITLE
Support media attribute

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -379,6 +379,8 @@ function getStylesheetHrefs(file) {
   const isNotPrint = (el) =>
     el.attr('media') !== 'print' || (Boolean(el.attr('onload')) && el.attr('onload').includes('media'));
 
+  const hasMeaningfulMedia = (el) => el.attr('media') && el.attr('media') !== 'print' && el.attr('media') !== 'all';
+
   const hrefs = stylesheets
     .filter((link) => isNotPrint(link.$el) && Boolean(link.value))
     .map((link) => {
@@ -389,6 +391,14 @@ function getStylesheetHrefs(file) {
 
       if (link.type === 'styles') {
         return Buffer.from(link.value);
+      }
+
+      if (hasMeaningfulMedia(link.$el)) {
+        if (link.value.includes('?')) {
+          link.value += `&media=${encodeURI(link.$el.attr('media'))}`;
+        } else {
+          link.value += `?media=${encodeURI(link.$el.attr('media'))}`;
+        }
       }
 
       return link.value;

--- a/test/file.test.js
+++ b/test/file.test.js
@@ -528,6 +528,20 @@ test('Get inline styles', async () => {
   }
 });
 
+test('Get styles with media attribute', async () => {
+  const docs = await mapAsync(
+    [`http://localhost:${port}/media-attr.html`, path.join(__dirname, 'fixtures/media-attr.html')],
+    (filepath) => getDocument(filepath)
+  );
+
+  const expected = '@media (max-width: 1024px)';
+
+  for (const document of docs) {
+    expect(document.stylesheets.toString()).toMatch('media=');
+    expect(document.css.toString()).toMatch(expected);
+  }
+});
+
 test('Get base64 styles', async () => {
   const docs = await mapAsync(
     [

--- a/test/fixtures/media-attr.html
+++ b/test/fixtures/media-attr.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html class="no-js">
+    <head>
+        <meta charset="utf-8">
+        <title>critical css test</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" href="styles/media-attr.css" media="(max-width: 1024px)">
+    </head>
+    <body>
+        <div class="container">
+            <div class="header"></div>
+        </div>
+    </body>
+</html>
+
+

--- a/test/fixtures/styles/media-attr.css
+++ b/test/fixtures/styles/media-attr.css
@@ -1,0 +1,3 @@
+.header {
+    display: flex;
+}


### PR DESCRIPTION
Adds support to wrap CSS with media query if the original `link` has a `media` attribute.

Fixes #443 