### PR TITLE
Allow multiple --css flags in cli fixes #514

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -48,6 +48,7 @@ const meowOpts = {
     css: {
       type: 'string',
       alias: 'c',
+      isMultiple: true,
     },
     width: {
       alias: 'w',

--- a/src/file.js
+++ b/src/file.js
@@ -864,7 +864,7 @@ async function getCss(document, options = {}) {
   const {css} = options;
   let stylesheets = [];
 
-  if (!Array.isArray(css) && css || (Array.isArray(css) && a.length !== 0)) {
+  if ((!Array.isArray(css) && css) || (Array.isArray(css) && a.length !== 0)) {
     const files = await glob(css, options);
     stylesheets = await mapAsync(files, (file) => getStylesheet(document, file, options));
     debug('(getCss) css option set', files, stylesheets);

--- a/src/file.js
+++ b/src/file.js
@@ -864,7 +864,7 @@ async function getCss(document, options = {}) {
   const {css} = options;
   let stylesheets = [];
 
-  if (css) {
+  if (!Array.isArray(css) && css || (Array.isArray(css) && a.length !== 0)) {
     const files = await glob(css, options);
     stylesheets = await mapAsync(files, (file) => getStylesheet(document, file, options));
     debug('(getCss) css option set', files, stylesheets);

--- a/src/file.js
+++ b/src/file.js
@@ -864,7 +864,7 @@ async function getCss(document, options = {}) {
   const {css} = options;
   let stylesheets = [];
 
-  if ((!Array.isArray(css) && css) || (Array.isArray(css) && a.length !== 0)) {
+  if ((!Array.isArray(css) && css) || (Array.isArray(css) && css.length > 0)) {
     const files = await glob(css, options);
     stylesheets = await mapAsync(files, (file) => getStylesheet(document, file, options));
     debug('(getCss) css option set', files, stylesheets);


### PR DESCRIPTION
Multiple --css flags were lost in v2.0, this restores the possibility of multiple --css flags
Fixes #514