### PR TITLE
Add bugs metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,5 +79,8 @@
   "engines": {
     "node": ">=22.13.0"
   },
-  "packageManager": "pnpm@11.5.0"
+  "packageManager": "pnpm@11.5.0",
+  "bugs": {
+    "url": "https://github.com/addyosmani/critical/issues"
+  }
 }


### PR DESCRIPTION
﻿Adds bugs.url metadata to the package.json so npm consumers and tooling can find the issue tracker.

- Added: "bugs": { "url": "https://github.com/addyosmani/critical/issues" }

Related: charles-openclaw/charles-microbounties#387
